### PR TITLE
Add Telegram bot and Flask admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
-# tsb
-telegram shop bot
+# Telegram Shop Bot
+
+Dieses Projekt beinhaltet einen einfachen Telegram-Bot und eine Admin-Oberfläche
+zum Verwalten von Produkten. Der Bot ist mit aiogram 3.x umgesetzt, die
+Admin-GUI basiert auf Flask.
+
+## Funktionen
+
+* Bot fragt bei `/start` die Sprache ab (Deutsch oder Englisch) und speichert
+diese Einstellung für den Nutzer.
+* Erste Menü-Ausgabe "Wähle ein Produkt" bzw. "Choose a product" je nach Sprache.
+* Admin-Login (Benutzer `admin`, Passwort `q12wq12w`).
+* Produktverwaltung mit Name, Preis und Beschreibung.
+* GUI läuft lokal auf Port 8000.
+
+## Setup
+
+Das Skript `setup.sh` richtet eine Python-`venv` ein, installiert die
+Abhängigkeiten und erstellt systemd-Dienste für Bot und GUI.
+
+```bash
+./setup.sh
+```
+
+Nach dem Start ist der Bot über Telegram erreichbar (Token per
+`BOT_TOKEN`-Umgebungsvariable setzen) und die Admin-GUI unter
+[http://localhost:8000](http://localhost:8000).

--- a/admin_app.py
+++ b/admin_app.py
@@ -1,0 +1,115 @@
+from flask import request, redirect, url_for, render_template_string, session
+from db import create_app, db, Product
+
+app = create_app()
+
+ADMIN_USER = 'admin'
+ADMIN_PASS = 'q12wq12w'
+
+
+def login_required(func):
+    from functools import wraps
+
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        if not session.get('logged_in'):
+            return redirect(url_for('login'))
+        return func(*args, **kwargs)
+    return wrapped
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        if (request.form.get('username') == ADMIN_USER and
+                request.form.get('password') == ADMIN_PASS):
+            session['logged_in'] = True
+            return redirect(url_for('product_list'))
+    return render_template_string('''
+        <form method="post">
+            <input name="username" placeholder="Username">
+            <input name="password" type="password" placeholder="Password">
+            <button type="submit">Login</button>
+        </form>''')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+
+@app.route('/')
+@login_required
+def product_list():
+    products = Product.query.all()
+    return render_template_string('''
+        <a href="{{ url_for('add_product') }}">Neues Produkt</a>
+        <ul>
+        {% for p in products %}
+            <li>
+                {{ p.name }} - {{ p.price }} € - {{ p.description }}
+                <a href="{{ url_for('edit_product', pid=p.id) }}">Edit</a>
+                <a href="{{ url_for('delete_product', pid=p.id) }}">Delete</a>
+            </li>
+        {% endfor %}
+        </ul>
+    ''', products=products)
+
+
+@app.route('/add', methods=['GET', 'POST'])
+@login_required
+def add_product():
+    if request.method == 'POST':
+        name = request.form['name']
+        price = float(request.form['price'])
+        desc = request.form['description']
+        db.session.add(Product(name=name, price=price, description=desc))
+        db.session.commit()
+        return redirect(url_for('product_list'))
+    return render_template_string('''
+        <form method="post">
+            <input name="name" placeholder="Name">
+            <input name="price" placeholder="Price" type="number" step="0.01">
+            <textarea name="description" placeholder="Beschreibung"></textarea>
+            <button type="submit">Save</button>
+        </form>
+    ''')
+
+
+@app.route('/edit/<int:pid>', methods=['GET', 'POST'])
+@login_required
+def edit_product(pid):
+    product = Product.query.get_or_404(pid)
+    if request.method == 'POST':
+        product.name = request.form['name']
+        product.price = float(request.form['price'])
+        product.description = request.form['description']
+        db.session.commit()
+        return redirect(url_for('product_list'))
+    return render_template_string('''
+        <form method="post">
+            <input name="name" value="{{ p.name }}">
+            <input name="price" type="number" step="0.01" value="{{ p.price }}">
+            <textarea name="description">{{ p.description }}</textarea>
+            <button type="submit">Save</button>
+        </form>
+    ''', p=product)
+
+
+@app.route('/delete/<int:pid>')
+@login_required
+def delete_product(pid):
+    product = Product.query.get_or_404(pid)
+    db.session.delete(product)
+    db.session.commit()
+    return redirect(url_for('product_list'))
+
+
+def main():
+    app.run(port=8000)
+
+
+if __name__ == '__main__':
+    main()

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,64 @@
+import os
+from aiogram import Bot, Dispatcher, types
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
+from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
+from aiogram import F
+
+from sqlalchemy.orm import Session
+from db import engine, User
+
+
+class LangStates(StatesGroup):
+    choose = State()
+
+
+def get_bot_token():
+    token = os.getenv("BOT_TOKEN")
+    if not token:
+        raise RuntimeError("BOT_TOKEN environment variable missing")
+    return token
+
+
+bot = Bot(get_bot_token())
+dp = Dispatcher()
+
+
+@dp.message(Command("start"))
+async def cmd_start(message: types.Message, state: FSMContext):
+    with Session(engine) as session:
+        user = session.query(User).filter_by(telegram_id=message.from_user.id).first()
+        if not user or not user.language:
+            kb = ReplyKeyboardMarkup(keyboard=[
+                [KeyboardButton(text="Deutsch"), KeyboardButton(text="English")]
+            ], resize_keyboard=True)
+            await message.answer("Choose your language / Wähle deine Sprache", reply_markup=kb)
+            await state.set_state(LangStates.choose)
+        else:
+            greeting = "W\u00e4hle ein Produkt" if user.language == "de" else "Choose a product"
+            await message.answer(greeting)
+
+
+@dp.message(LangStates.choose)
+async def set_language(message: types.Message, state: FSMContext):
+    lang = "de" if message.text.lower().startswith("de") else "en"
+    with Session(engine) as session:
+        user = session.query(User).filter_by(telegram_id=message.from_user.id).first()
+        if not user:
+            user = User(telegram_id=message.from_user.id, language=lang)
+            session.add(user)
+        else:
+            user.language = lang
+        session.commit()
+    await state.clear()
+    greeting = "W\u00e4hle ein Produkt" if lang == "de" else "Choose a product"
+    await message.answer(greeting, reply_markup=types.ReplyKeyboardRemove())
+
+
+def main():
+    dp.run_polling(bot)
+
+
+if __name__ == "__main__":
+    main()

--- a/db.py
+++ b/db.py
@@ -1,0 +1,45 @@
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import Column, Integer, String, Float
+
+DATABASE_URL = "sqlite:///db.sqlite3"
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine)
+Base = declarative_base()
+
+
+class Product(Base):
+    __tablename__ = "products"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(100))
+    price = Column(Float)
+    description = Column(String(255))
+
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    telegram_id = Column(Integer, unique=True)
+    language = Column(String(10))
+
+
+def init_db():
+    Base.metadata.create_all(engine)
+
+
+# Flask integration
+from flask import Flask
+
+db = SQLAlchemy()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URL
+    app.config['SECRET_KEY'] = 'change-me'
+    db.init_app(app)
+    with app.app_context():
+        init_db()
+    return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiogram>=3,<4
+Flask
+flask_sqlalchemy

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_DIR="$REPO_DIR/venv"
+
+python3 -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install -r "$REPO_DIR/requirements.txt"
+
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+mkdir -p "$SYSTEMD_USER_DIR"
+
+echo "[Unit]" > "$SYSTEMD_USER_DIR/bot.service"
+cat >> "$SYSTEMD_USER_DIR/bot.service" <<SERVICE
+Description=Telegram Shop Bot
+After=network.target
+[Service]
+WorkingDirectory=$REPO_DIR
+ExecStart=$VENV_DIR/bin/python $REPO_DIR/bot.py
+Restart=always
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+
+echo "[Unit]" > "$SYSTEMD_USER_DIR/gui.service"
+cat >> "$SYSTEMD_USER_DIR/gui.service" <<SERVICE
+Description=Flask Admin GUI
+After=network.target
+[Service]
+WorkingDirectory=$REPO_DIR
+ExecStart=$VENV_DIR/bin/python $REPO_DIR/admin_app.py
+Restart=always
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl --user daemon-reload
+systemctl --user enable --now bot.service gui.service
+
+echo "Telegram Bot started. Configure it via Telegram."
+echo "Admin GUI available at http://localhost:8000" 


### PR DESCRIPTION
## Summary
- implement aiogram telegram bot with language selection
- create Flask admin GUI for product management
- add SQLAlchemy models
- provide setup script for venv and systemd services
- fix systemd service paths in setup script

## Testing
- `python3 -m py_compile bot.py admin_app.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_6840461c5f9c83238ed1218c640f347a