### PR TITLE
Enable CSRF and hashed admin password

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram>=3,<4
 Flask
 flask_sqlalchemy
+Flask-WTF


### PR DESCRIPTION
## Summary
- hash admin password with werkzeug
- protect forms with CSRF tokens via Flask-WTF
- update requirements

## Testing
- `python3 -m py_compile admin_app.py`
- `python3 -m py_compile bot.py db.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684051fd6698832390133b205f086f23