### PR TITLE
Improve cross platform instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@ Admin-GUI basiert auf Flask.
 * Bot fragt bei `/start` die Sprache ab (Deutsch oder Englisch) und speichert
 diese Einstellung für den Nutzer.
 * Erste Menü-Ausgabe "Wähle ein Produkt" bzw. "Choose a product" je nach Sprache.
-* Admin-Login (Benutzer `admin`, Passwort `q12wq12w`).
+* Admin-Login (Benutzer `admin`, Passwort `q12wq12w`; Werte über
+  `ADMIN_USER` und `ADMIN_PASS` anpassbar).
 * Produktverwaltung mit Name, Preis und Beschreibung.
 * GUI läuft lokal auf Port 8000.
 
 ## Setup
 
 Das Skript `setup.sh` richtet eine Python-`venv` ein, installiert die
-Abhängigkeiten und erstellt systemd-Dienste für Bot und GUI.
+Abhängigkeiten und – falls möglich – erstellt systemd-Dienste für Bot und GUI.
 
 ```bash
 ./setup.sh
@@ -25,3 +26,33 @@ Abhängigkeiten und erstellt systemd-Dienste für Bot und GUI.
 Nach dem Start ist der Bot über Telegram erreichbar (Token per
 `BOT_TOKEN`-Umgebungsvariable setzen) und die Admin-GUI unter
 [http://localhost:8000](http://localhost:8000).
+Die Datei `tsb.env` enthält Platzhalter für diese Variablen und wird beim
+Setup automatisch angelegt.
+
+### Manuelles Starten (macOS/Windows)
+
+Auf Systemen ohne systemd müssen Bot und GUI manuell gestartet werden.
+Installieren Sie zuerst die Abhängigkeiten:
+
+```bash
+python -m venv venv
+source venv/bin/activate  # auf Windows: venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+Legen Sie anschließend folgende Umgebungsvariablen fest:
+
+```bash
+export BOT_TOKEN=<Ihr-Token>
+export ADMIN_USER=admin
+export ADMIN_PASS=q12wq12w
+```
+Sie können diese Werte auch in der Datei `tsb.env` hinterlegen und
+vor dem Start mit `source tsb.env` einlesen.
+
+Starten Sie danach beide Programme jeweils in einem Terminal:
+
+```bash
+python bot.py
+python admin_app.py
+```

--- a/admin_app.py
+++ b/admin_app.py
@@ -1,10 +1,13 @@
+import os
 from flask import request, redirect, url_for, render_template_string, session
 from db import create_app, db, Product
 
 app = create_app()
 
-ADMIN_USER = 'admin'
-ADMIN_PASS = 'q12wq12w'
+# Allow overriding admin credentials via environment variables so unit files can
+# reference an environment file instead of hard coding secrets.
+ADMIN_USER = os.getenv('ADMIN_USER', 'admin')
+ADMIN_PASS = os.getenv('ADMIN_PASS', 'q12wq12w')
 
 
 def login_required(func):

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,7 @@ set -e
 
 REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 VENV_DIR="$REPO_DIR/venv"
+ENV_FILE="$REPO_DIR/tsb.env"
 
 python3 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
@@ -10,33 +11,49 @@ source "$VENV_DIR/bin/activate"
 pip install --upgrade pip
 pip install aiogram flask flask_sqlalchemy
 
-echo "[Unit]" > bot.service
-cat >> bot.service <<SERVICE
+if [ ! -f "$ENV_FILE" ]; then
+  cat > "$ENV_FILE" <<EOF
+BOT_TOKEN=
+ADMIN_USER=admin
+ADMIN_PASS=q12wq12w
+EOF
+  echo "Created example environment file at $ENV_FILE"
+fi
+
+if [[ "$(uname -s)" == "Linux" && -n "$(command -v systemctl)" ]]; then
+  echo "[Unit]" > bot.service
+  cat >> bot.service <<SERVICE
 Description=Telegram Shop Bot
 After=network.target
 [Service]
 WorkingDirectory=$REPO_DIR
+EnvironmentFile=$ENV_FILE
 ExecStart=$VENV_DIR/bin/python $REPO_DIR/bot.py
 Restart=always
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 SERVICE
 
-
-echo "[Unit]" > gui.service
-cat >> gui.service <<SERVICE
+  echo "[Unit]" > gui.service
+  cat >> gui.service <<SERVICE
 Description=Flask Admin GUI
 After=network.target
 [Service]
 WorkingDirectory=$REPO_DIR
+EnvironmentFile=$ENV_FILE
 ExecStart=$VENV_DIR/bin/python $REPO_DIR/admin_app.py
 Restart=always
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 SERVICE
 
-systemctl --user daemon-reload
-systemctl --user enable --now bot.service gui.service
+  systemctl --user daemon-reload
+  systemctl --user enable --now bot.service gui.service
+  echo "Services installed. Admin GUI available at http://localhost:8000"
+else
+  echo "Systemd not available. Start the applications manually with:" >&2
+  echo "source $ENV_FILE && $VENV_DIR/bin/python bot.py" >&2
+  echo "source $ENV_FILE && $VENV_DIR/bin/python admin_app.py" >&2
+fi
 
-echo "Telegram Bot started. Configure it via Telegram."
-echo "Admin GUI available at http://localhost:8000" 
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- allow admin credentials to be set via env vars
- create an environment file in `setup.sh`
- detect systemd availability and skip service creation when missing
- update README with manual startup steps for macOS/Windows

## Testing
- `python -m py_compile bot.py admin_app.py db.py`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_684051fefaec8323b5973640f59d8f0b