### PR TITLE
Add .gitignore and warn about committing .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Virtual environments
+venv/
+env/
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Environment variables
+.env
+
+# Editor directories
+.vscode/
+.idea/
+
+# Systemd service files
+*.service
+
+# Build artifacts
+build/
+dist/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@ Folgende Variablen müssen für die Dienste gesetzt sein:
 * `ADMIN_USER` – Benutzername für das Admin-Login
 * `ADMIN_PASS` – Passwort für das Admin-Login
 * `SECRET_KEY` – Flask-`SECRET_KEY` für die Web-Oberfläche
+
+Die Werte können beispielsweise in einer `.env`-Datei gespeichert werden.
+Diese Datei darf **nicht** ins Repository eingecheckt werden.


### PR DESCRIPTION
## Summary
- add new `.gitignore` covering virtualenvs, caches, systemd services and build output
- warn in README not to commit the `.env` file

## Testing
- `python3 -m py_compile bot.py admin_app.py db.py`


------
https://chatgpt.com/codex/tasks/task_e_684054bbddb4832387f35fd863f37d1e