### PR TITLE
Add environment variables for admin host/port

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ die folgenden Variablen enthalten:
 * `ADMIN_USER` – Benutzername für das Admin-Login
 * `ADMIN_PASS` – Passwort für das Admin-Login
 * `SECRET_KEY` – Flask-`SECRET_KEY` für die Web-Oberfläche
+* `ADMIN_HOST` – Hostname/IP für die Admin-GUI (Standard: `127.0.0.1`)
+* `ADMIN_PORT` – Port der Admin-GUI (Standard: `8000`)
 
 Die Werte können beispielsweise in einer `.env`-Datei gespeichert werden.
 Diese Datei darf **nicht** ins Repository eingecheckt werden.

--- a/admin_app.py
+++ b/admin_app.py
@@ -4,6 +4,8 @@ from flask import request, redirect, url_for, render_template_string, session
 from db import create_app, db, Product
 
 app = create_app()
+ADMIN_HOST = os.getenv("ADMIN_HOST", "127.0.0.1")
+ADMIN_PORT = int(os.getenv("ADMIN_PORT", "8000"))
 
 def login_required(func):
     from functools import wraps
@@ -106,7 +108,7 @@ def delete_product(pid):
 
 
 def main():
-    app.run(port=8000)
+    app.run(host=ADMIN_HOST, port=ADMIN_PORT)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- make `ADMIN_HOST` and `ADMIN_PORT` configurable
- mention the variables in the README

## Testing
- `python3 -m py_compile admin_app.py bot.py db.py`

------
https://chatgpt.com/codex/tasks/task_e_68406e3501bc83238956620a6f019b8b