### PR TITLE
Use env file in services

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ oder macOS.
 ./setup.sh
 ```
 
+Alternativ kann das Setup komplett in Python ausgeführt werden:
+
+```bash
+python setup.py
+```
+Dieses Skript legt ebenfalls eine virtuelle Umgebung an, speichert die
+benötigten Variablen in `.env` und erzeugt die systemd-Dienste.
+
 
 Nach dem Start ist der Bot über Telegram erreichbar (Token per
 `BOT_TOKEN`-Umgebungsvariable setzen) und die Admin-GUI unter

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from venv import EnvBuilder
 
 REPO_DIR = Path(__file__).resolve().parent
 VENV_DIR = REPO_DIR / "venv"
+ENV_FILE = REPO_DIR / ".env"
 
 
 def create_venv():
@@ -30,7 +31,25 @@ def prompt_env(var):
     value = os.getenv(var)
     if not value:
         value = input(f"{var}: ")
+    os.environ[var] = value
     return value
+
+
+def load_env_file():
+    data = {}
+    if ENV_FILE.exists():
+        with ENV_FILE.open() as f:
+            for line in f:
+                if "=" in line:
+                    k, v = line.strip().split("=", 1)
+                    data[k] = v
+    return data
+
+
+def write_env_file(env):
+    with ENV_FILE.open("w") as f:
+        for k, v in env.items():
+            f.write(f"{k}={v}\n")
 
 
 def create_services(python_exe, env):
@@ -41,26 +60,24 @@ def create_services(python_exe, env):
         print(f"  {python_exe} admin_app.py")
         return
 
-    bot_service = (REPO_DIR / "bot.service").write_text(f"""[Unit]
+    (REPO_DIR / "bot.service").write_text(f"""[Unit]
 Description=Telegram Shop Bot
 After=network.target
 [Service]
 WorkingDirectory={REPO_DIR}
-Environment=BOT_TOKEN={env['BOT_TOKEN']}
+EnvironmentFile={ENV_FILE}
 ExecStart={python_exe} {REPO_DIR / 'bot.py'}
 Restart=always
 [Install]
 WantedBy=multi-user.target
 """)
 
-    gui_service = (REPO_DIR / "gui.service").write_text(f"""[Unit]
+    (REPO_DIR / "gui.service").write_text(f"""[Unit]
 Description=Flask Admin GUI
 After=network.target
 [Service]
 WorkingDirectory={REPO_DIR}
-Environment=ADMIN_USER={env['ADMIN_USER']}
-Environment=ADMIN_PASS={env['ADMIN_PASS']}
-Environment=SECRET_KEY={env['SECRET_KEY']}
+EnvironmentFile={ENV_FILE}
 ExecStart={python_exe} {REPO_DIR / 'admin_app.py'}
 Restart=always
 [Install]
@@ -75,10 +92,11 @@ def main():
     python_exe, pip_exe = create_venv()
     install_deps(pip_exe)
 
-    env = {
-        var: prompt_env(var)
-        for var in ["BOT_TOKEN", "ADMIN_USER", "ADMIN_PASS", "SECRET_KEY"]
-    }
+    env = load_env_file()
+    for var in ["BOT_TOKEN", "ADMIN_USER", "ADMIN_PASS", "SECRET_KEY"]:
+        env[var] = env.get(var) or prompt_env(var)
+
+    write_env_file(env)
 
     create_services(python_exe, env)
     print("Setup complete.")


### PR DESCRIPTION
## Summary
- set `.env` path in setup.py and read/write it
- reference `EnvironmentFile=` in generated service files
- document python setup option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68406f1c05988323b6018cd1d4a9138e