### PR TITLE
Clarify setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,22 +15,27 @@ diese Einstellung für den Nutzer.
 
 ## Setup
 
-Das Skript `setup.sh` richtet eine Python-`venv` ein, installiert die
-Abhängigkeiten und erstellt systemd-Dienste für Bot und GUI.
-Es setzt eine Unix-Shell (bash) voraus und funktioniert daher unter Linux
-oder macOS.
+Das Projekt bietet zwei gleichwertige Skripte zum Einrichten der
+Entwicklungsumgebung:
+
+* `setup.sh` – Bash-Skript für Linux/macOS.
+* `setup.py` – Python-Variante, die auch unter Windows funktioniert.
+
+Beide Skripte legen eine virtuelle Umgebung im Ordner `venv` an, installieren
+die Abhängigkeiten aus `requirements.txt`, schreiben die benötigten Variablen in
+eine `.env`-Datei und erzeugen auf Linux die systemd-Dienste für Bot und GUI.
+
+Unter Unix-Systemen führst du typischerweise das Shell-Skript aus:
 
 ```bash
 ./setup.sh
 ```
 
-Alternativ kann das Setup komplett in Python ausgeführt werden:
+Auf allen Plattformen kannst du alternativ das Python-Skript verwenden:
 
 ```bash
 python setup.py
 ```
-Dieses Skript legt ebenfalls eine virtuelle Umgebung an, speichert die
-benötigten Variablen in `.env` und erzeugt die systemd-Dienste.
 
 
 Nach dem Start ist der Bot über Telegram erreichbar (Token per

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,8 @@ python3 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 
 pip install --upgrade pip
-pip install aiogram flask flask_sqlalchemy
+# install dependencies defined in requirements.txt to stay in sync with setup.py
+pip install -r "$REPO_DIR/requirements.txt"
 
 # load existing variables from .env if present
 if [ -f "$ENV_FILE" ]; then


### PR DESCRIPTION
## Summary
- document which setup script to run
- use requirements.txt for setup.sh as well so both scripts behave the same

## Testing
- `python -m py_compile admin_app.py bot.py db.py setup.py`
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_6840709187108323b6a331877061f088