### PR TITLE
Support DATABASE_URL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ die folgenden Variablen enthalten:
 * `ADMIN_USER` – Benutzername für das Admin-Login
 * `ADMIN_PASS` – Passwort für das Admin-Login
 * `SECRET_KEY` – Flask-`SECRET_KEY` für die Web-Oberfläche
+* `DATABASE_URL` – optionale Datenbank-URL (Standard: `sqlite:///db.sqlite3`)
 * `ADMIN_HOST` – Hostname/IP für die Admin-GUI (Standard: `127.0.0.1`)
 * `ADMIN_PORT` – Port der Admin-GUI (Standard: `8000`)
 

--- a/db.py
+++ b/db.py
@@ -3,7 +3,9 @@ from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.orm import sessionmaker
 from flask import Flask
 
-DATABASE_URL = "sqlite:///db.sqlite3"
+# Allow overriding the database via environment variable.
+# Falls back to the local SQLite file if not provided.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///db.sqlite3")
 
 db = SQLAlchemy()
 SessionLocal = sessionmaker()


### PR DESCRIPTION
## Summary
- read DATABASE_URL in db.py with fallback to sqlite
- document new variable in README

## Testing
- `python -m py_compile admin_app.py bot.py db.py setup.py`

------
https://chatgpt.com/codex/tasks/task_e_6840712c63108323816c70246947cb7d