### PR TITLE
Add pytest tests for DB and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ die folgenden Variablen enthalten:
 
 Die Werte können beispielsweise in einer `.env`-Datei gespeichert werden.
 Diese Datei darf **nicht** ins Repository eingecheckt werden.
+
+## Tests
+
+Die Unit-Tests werden mit pytest ausgeführt. Nach dem Installieren der Abhängigkeiten kannst du sie direkt mit `pytest` ausführen.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 aiogram>=3,<4
 Flask
 flask_sqlalchemy
+
+pytest

--- a/tests/test_admin_login.py
+++ b/tests/test_admin_login.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+import importlib
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_admin_login(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.sqlite3'
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_path}')
+    monkeypatch.setenv('SECRET_KEY', 'test')
+    monkeypatch.setenv('ADMIN_USER', 'admin')
+    monkeypatch.setenv('ADMIN_PASS', 'pass')
+
+    if 'db' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('db'))
+    if 'admin_app' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('admin_app'))
+    admin_app = importlib.import_module('admin_app')
+    app = admin_app.app
+    client = app.test_client()
+
+    resp = client.post('/login', data={'username': 'admin', 'password': 'pass'})
+    assert resp.status_code == 302
+    assert resp.headers['Location'].endswith('/')
+    with client.session_transaction() as sess:
+        assert sess.get('logged_in') is True

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,25 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import importlib
+
+
+def test_create_product(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.sqlite3'
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_path}')
+    monkeypatch.setenv('SECRET_KEY', 'test')
+    importlib.reload(importlib.import_module('db'))
+    from db import create_app, SessionLocal, Product
+    app = create_app()
+    with app.app_context():
+        with SessionLocal() as session:
+            product = Product(name='Test', price=9.99, description='demo')
+            session.add(product)
+            session.commit()
+            assert session.query(Product).count() == 1
+            stored = session.query(Product).first()
+            assert stored.name == 'Test'
+            assert stored.price == 9.99
+            assert stored.description == 'demo'


### PR DESCRIPTION
## Summary
- add pytest to requirements
- test product creation and admin login
- document how to run tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684072610fcc83239938e056d69edc66