### PR TITLE
Fix systemctl paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Entwicklungsumgebung:
 Beide Skripte legen eine virtuelle Umgebung im Ordner `venv` an, installieren
 die Abhängigkeiten aus `requirements.txt`, schreiben die benötigten Variablen in
 eine `.env`-Datei und erzeugen auf Linux die systemd-Dienste für Bot und GUI.
+Die Dienste werden dabei mit absoluten Pfaden aktiviert:
+`systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"`.
+Zuvor wird automatisch `systemctl --user daemon-reload` ausgeführt.
 
 Unter Unix-Systemen führst du typischerweise das Shell-Skript aus:
 
@@ -83,7 +86,8 @@ The project provides two equivalent scripts for setting up the development envir
 * `setup.sh` – Bash script for Linux/macOS.
 * `setup.py` – Python variant that also works on Windows.
 
-Both scripts create a virtual environment in the `venv` folder, install the dependencies from `requirements.txt`, write the required variables to a `.env` file and on Linux create the systemd services for bot and GUI.
+Both scripts create a virtual environment in the `venv` folder, install the dependencies from `requirements.txt`, write the required variables to a `.env` file and on Linux create the systemd services for bot and GUI. The services are enabled using absolute paths:
+`systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"`. `systemctl --user daemon-reload` is executed automatically before enabling them.
 
 On Unix systems you typically run the shell script:
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,14 @@ WantedBy=multi-user.target
 """)
 
     subprocess.check_call(["systemctl", "--user", "daemon-reload"])
-    subprocess.check_call(["systemctl", "--user", "enable", "--now", "bot.service", "gui.service"])
+    subprocess.check_call([
+        "systemctl",
+        "--user",
+        "enable",
+        "--now",
+        str(REPO_DIR / "bot.service"),
+        str(REPO_DIR / "gui.service"),
+    ])
 
 
 def main():

--- a/setup.sh
+++ b/setup.sh
@@ -73,7 +73,7 @@ WantedBy=multi-user.target
 SERVICE
 
 systemctl --user daemon-reload
-systemctl --user enable --now bot.service gui.service
+systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"
 
 echo "Telegram Bot started. Configure it via Telegram."
 echo "Admin GUI available at http://localhost:8000" 


### PR DESCRIPTION
## Summary
- use absolute paths when enabling systemd user services in setup scripts
- note that daemon-reload runs and services are enabled via absolute paths in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407718583c83238d795dbfb97cdfee