### PR TITLE
Handle missing systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Auf allen Plattformen kannst du alternativ das Python-Skript verwenden:
 python setup.py
 ```
 
+Sollte `systemctl --user` nicht verfügbar sein, starte Bot und GUI manuell:
+
+```bash
+python bot.py
+python admin_app.py
+```
+
 
 Nach dem Start ist der Bot über Telegram erreichbar (Token per
 `BOT_TOKEN`-Umgebungsvariable setzen) und die Admin-GUI unter
@@ -99,6 +106,13 @@ On any platform you can alternatively use the Python script:
 
 ```bash
 python setup.py
+```
+
+If `systemctl --user` is not available, start bot and GUI manually:
+
+```bash
+python bot.py
+python admin_app.py
 ```
 
 After starting, the bot is reachable via Telegram (set the token with the `BOT_TOKEN` environment variable) and the admin GUI is available at [http://localhost:8000](http://localhost:8000).

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,18 @@ def create_services(python_exe, env):
         print(f"  {python_exe} admin_app.py")
         return
 
+    try:
+        subprocess.check_call([
+            "systemctl",
+            "--user",
+            "--version",
+        ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("systemd not available. Start the scripts manually:")
+        print(f"  {python_exe} bot.py")
+        print(f"  {python_exe} admin_app.py")
+        return
+
     (REPO_DIR / "bot.service").write_text(f"""[Unit]
 Description=Telegram Shop Bot
 After=network.target

--- a/setup.sh
+++ b/setup.sh
@@ -72,8 +72,15 @@ Restart=always
 WantedBy=multi-user.target
 SERVICE
 
-systemctl --user daemon-reload
-systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"
+if systemctl --user --version >/dev/null 2>&1; then
+    systemctl --user daemon-reload
+    systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"
+else
+    echo "systemd not available, skipping service creation."
+    echo "Start the services manually:" >&2
+    echo "  $VENV_DIR/bin/python $REPO_DIR/bot.py" >&2
+    echo "  $VENV_DIR/bin/python $REPO_DIR/admin_app.py" >&2
+fi
 
 echo "Telegram Bot started. Configure it via Telegram."
 echo "Admin GUI available at http://localhost:8000" 


### PR DESCRIPTION
## Summary
- check for `systemctl --user` in setup scripts
- skip systemd service creation when not available and print manual instructions
- document manual bot and admin GUI startup in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407892f3ac8323a0401f9e3a69954c