### PR TITLE
Fix DB init for bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -8,8 +8,6 @@ from aiogram import F
 
 from db import create_app, SessionLocal, User
 
-create_app()
-
 
 class LangStates(StatesGroup):
     choose = State()
@@ -58,6 +56,7 @@ async def set_language(message: types.Message, state: FSMContext):
 
 
 def main():
+    create_app()
     dp.run_polling(bot)
 
 


### PR DESCRIPTION
## Summary
- move `create_app()` call inside `main()`
- remove top-level DB initialization

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840795013b483239604562de056a8e5