### PR TITLE
Add Tor hidden service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ die folgenden Variablen enthalten:
 * `DATABASE_URL` – optionale Datenbank-URL (Standard: `sqlite:///db.sqlite3`)
 * `ADMIN_HOST` – Hostname/IP für die Admin-GUI (Standard: `127.0.0.1`)
 * `ADMIN_PORT` – Port der Admin-GUI (Standard: `8000`)
+* `TOR_CONTROL_PORT` – optionaler ControlPort von Tor (Standard: `9051`)
+* `TOR_PASSWORD` – Passwort für den Tor-ControlPort
+* `TOR_SERVICE_PORT` – Port der Hidden Service-Adresse (Standard: `80`)
 
 Die Werte können beispielsweise in einer `.env`-Datei gespeichert werden.
 Diese Datei darf **nicht** ins Repository eingecheckt werden.
@@ -132,6 +135,9 @@ The systemd services load their configuration from the `.env` file. It must cont
 * `DATABASE_URL` – optional database URL (default: `sqlite:///db.sqlite3`)
 * `ADMIN_HOST` – Hostname/IP for the admin GUI (default: `127.0.0.1`)
 * `ADMIN_PORT` – Port of the admin GUI (default: `8000`)
+* `TOR_CONTROL_PORT` – optional Tor ControlPort (default: `9051`)
+* `TOR_PASSWORD` – password for the Tor ControlPort
+* `TOR_SERVICE_PORT` – port exposed by the hidden service (default: `80`)
 
 You can store these values in a `.env` file. This file must **not** be committed to the repository.
 

--- a/admin_app.py
+++ b/admin_app.py
@@ -111,7 +111,25 @@ def delete_product(pid):
 
 
 def main():
-    app.run(host=ADMIN_HOST, port=ADMIN_PORT)
+    """Start the admin web app and optionally expose it as a Tor hidden service."""
+    onion_service = None
+    ctx = None
+    if os.getenv("TOR_CONTROL_PORT"):
+        try:
+            from tor_service import hidden_service
+            ctx = hidden_service(ADMIN_PORT)
+            onion_service = ctx.__enter__()
+            print(f"Tor hidden service available at http://{onion_service}")
+        except Exception as exc:  # pragma: no cover - Tor optional in tests
+            print(f"Failed to start Tor hidden service: {exc}")
+            onion_service = None
+            ctx = None
+
+    try:
+        app.run(host=ADMIN_HOST, port=ADMIN_PORT)
+    finally:
+        if onion_service is not None and ctx is not None:
+            ctx.__exit__(None, None, None)
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiogram>=3,<4
 Flask
 flask_sqlalchemy
+stem
 
 pytest

--- a/tor_service.py
+++ b/tor_service.py
@@ -1,0 +1,32 @@
+import os
+from contextlib import contextmanager
+
+try:
+    from stem.control import Controller
+except ImportError:  # pragma: no cover - stem is an optional dependency in tests
+    Controller = None
+
+
+def _get_tor_config():
+    control_port = int(os.getenv("TOR_CONTROL_PORT", "9051"))
+    password = os.getenv("TOR_PASSWORD")
+    service_port = int(os.getenv("TOR_SERVICE_PORT", "80"))
+    return control_port, password, service_port
+
+
+@contextmanager
+def hidden_service(local_port):
+    """Context manager that creates an ephemeral Tor hidden service."""
+    control_port, password, service_port = _get_tor_config()
+    if Controller is None:
+        raise RuntimeError("stem is required to use the hidden service feature")
+
+    controller = Controller.from_port(port=control_port)
+    controller.authenticate(password=password)
+    hs = controller.create_ephemeral_hidden_service({service_port: local_port}, await_publication=True)
+    onion = f"{hs.service_id}.onion"
+    try:
+        yield onion
+    finally:
+        controller.remove_ephemeral_hidden_service(hs.service_id)
+        controller.close()


### PR DESCRIPTION
## Summary
- add a new `tor_service` module for creating Tor hidden services
- make admin GUI optionally start a hidden service
- document new environment variables for Tor
- require `stem` package for Tor support

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684091c53fec832398b40ba2f9e06bfa