### PR TITLE
Add Tor status route and test

### DIFF
--- a/admin_app.py
+++ b/admin_app.py
@@ -1,5 +1,6 @@
 import os
-from flask import request, redirect, url_for, render_template_string, session
+from flask import request, redirect, url_for, render_template_string, session, jsonify
+from stem.control import Controller
 
 from db import create_app, db, Product
 
@@ -108,6 +109,21 @@ def delete_product(pid):
     db.session.delete(product)
     db.session.commit()
     return redirect(url_for('product_list'))
+
+
+@app.route('/tor')
+def tor_status():
+    port = int(os.getenv('TOR_CONTROL_PORT', '9051'))
+    password = os.getenv('TOR_CONTROL_PASS', '')
+    try:
+        with Controller.from_port(port=port) as controller:
+            if password:
+                controller.authenticate(password=password)
+            else:
+                controller.authenticate()
+        return jsonify({'status': 'ok'})
+    except Exception as exc:
+        return jsonify({'status': 'error', 'message': str(exc)}), 500
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ aiogram>=3,<4
 Flask
 flask_sqlalchemy
 
+stem
 pytest

--- a/tests/test_tor_route.py
+++ b/tests/test_tor_route.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import importlib
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_tor_route(tmp_path, monkeypatch):
+    db_path = tmp_path / 'test.sqlite3'
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_path}')
+    monkeypatch.setenv('SECRET_KEY', 'test')
+    monkeypatch.setenv('ADMIN_USER', 'admin')
+    monkeypatch.setenv('ADMIN_PASS', 'pass')
+
+    if 'db' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('db'))
+
+    dummy_controller = MagicMock()
+    dummy_controller.__enter__.return_value = dummy_controller
+    dummy_controller.__exit__.return_value = False
+    dummy_controller.authenticate.return_value = True
+
+    with patch('stem.control.Controller.from_port', return_value=dummy_controller) as mock_from_port:
+        if 'admin_app' in importlib.sys.modules:
+            importlib.reload(importlib.import_module('admin_app'))
+        admin_app = importlib.import_module('admin_app')
+        app = admin_app.app
+        client = app.test_client()
+
+        resp = client.get('/tor')
+        assert resp.status_code == 200
+        assert resp.json == {'status': 'ok'}
+        mock_from_port.assert_called_once()


### PR DESCRIPTION
## Summary
- expose `/tor` route in `admin_app` to check Tor control connectivity
- update dependencies with `stem`
- test `/tor` route by mocking Tor control

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684091c64ab4832386a2b31637c9d6c1