### PR TITLE
Implement Tor control settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ diese Einstellung für den Nutzer.
 * Admin-Login (Benutzername und Passwort über `ADMIN_USER` und `ADMIN_PASS`).
 * Produktverwaltung mit Name, Preis und Beschreibung.
 * GUI läuft lokal auf Port 8000.
-* Neue Route `/tor` ermöglicht das Ändern der Tor-Einstellungen.
+* Neue Route `/tor` ermöglicht das Steuern des Tor-Dienstes über die
+  Variablen `ENABLE_TOR`, `TOR_CONTROL_HOST`, `TOR_CONTROL_PORT` und
+  `TOR_CONTROL_PASS`.
 
 ## Setup
 
@@ -97,7 +99,9 @@ This project contains a simple Telegram bot and an admin interface for managing 
 * Admin login using the username and password from `ADMIN_USER` and `ADMIN_PASS`.
 * Manage products with name, price and description.
 * The GUI runs locally on port 8000.
-* New `/tor` route lets you modify Tor settings.
+* New `/tor` route allows controlling Tor using the `ENABLE_TOR`,
+  `TOR_CONTROL_HOST`, `TOR_CONTROL_PORT` and `TOR_CONTROL_PASS`
+  environment variables.
 
 ## Setup
 
@@ -141,6 +145,10 @@ The systemd services load their configuration from the `.env` file. It must cont
 * `DATABASE_URL` – optional database URL (default: `sqlite:///db.sqlite3`)
 * `ADMIN_HOST` – Hostname/IP for the admin GUI (default: `127.0.0.1`)
 * `ADMIN_PORT` – Port of the admin GUI (default: `8000`)
+* `ENABLE_TOR` – set to `1` to expose the admin GUI via Tor
+* `TOR_CONTROL_HOST` – host of the Tor control port (default: `127.0.0.1`)
+* `TOR_CONTROL_PORT` – port of the Tor control port (default: `9051`)
+* `TOR_CONTROL_PASS` – password for the Tor control port
 
 
 You can store these values in a `.env` file. This file must **not** be committed to the repository.

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -13,8 +13,10 @@ def test_tor_settings(tmp_path, monkeypatch):
     monkeypatch.setenv('SECRET_KEY', 'test')
     monkeypatch.setenv('ADMIN_USER', 'admin')
     monkeypatch.setenv('ADMIN_PASS', 'pass')
-    monkeypatch.setenv('TOR_HOST', 'localhost')
-    monkeypatch.setenv('TOR_PORT', '9050')
+    monkeypatch.setenv('ENABLE_TOR', '0')
+    monkeypatch.setenv('TOR_CONTROL_HOST', 'localhost')
+    monkeypatch.setenv('TOR_CONTROL_PORT', '9051')
+    monkeypatch.setenv('TOR_CONTROL_PASS', 'passw')
 
     if 'db' in importlib.sys.modules:
         importlib.reload(importlib.import_module('db'))
@@ -33,10 +35,14 @@ def test_tor_settings(tmp_path, monkeypatch):
     assert b'localhost' in resp.data
 
     # update settings
-    resp = client.post('/tor', data={'host': '127.0.0.1', 'port': '9051'})
+    resp = client.post('/tor', data={'enabled': 'on', 'host': '127.0.0.1', 'port': '9052', 'password': 'secret'})
     assert b'Settings updated' in resp.data
-    assert os.environ['TOR_HOST'] == '127.0.0.1'
-    assert os.environ['TOR_PORT'] == '9051'
+    assert os.environ['ENABLE_TOR'] == '1'
+    assert os.environ['TOR_CONTROL_HOST'] == '127.0.0.1'
+    assert os.environ['TOR_CONTROL_PORT'] == '9052'
+    assert os.environ['TOR_CONTROL_PASS'] == 'secret'
     saved = env_file.read_text()
-    assert 'TOR_HOST=127.0.0.1' in saved
-    assert 'TOR_PORT=9051' in saved
+    assert 'ENABLE_TOR=1' in saved
+    assert 'TOR_CONTROL_HOST=127.0.0.1' in saved
+    assert 'TOR_CONTROL_PORT=9052' in saved
+    assert 'TOR_CONTROL_PASS=secret' in saved

--- a/tor_service.py
+++ b/tor_service.py
@@ -8,20 +8,21 @@ except ImportError:  # pragma: no cover - stem is an optional dependency in test
 
 
 def _get_tor_config():
-    control_port = int(os.getenv("TOR_CONTROL_PORT", "9051"))
-    password = os.getenv("TOR_PASSWORD")
+    host = os.getenv("TOR_CONTROL_HOST", "127.0.0.1")
+    port = int(os.getenv("TOR_CONTROL_PORT", "9051"))
+    password = os.getenv("TOR_CONTROL_PASS")
     service_port = int(os.getenv("TOR_SERVICE_PORT", "80"))
-    return control_port, password, service_port
+    return host, port, password, service_port
 
 
 @contextmanager
 def hidden_service(local_port):
     """Context manager that creates an ephemeral Tor hidden service."""
-    control_port, password, service_port = _get_tor_config()
+    host, port, password, service_port = _get_tor_config()
     if Controller is None:
         raise RuntimeError("stem is required to use the hidden service feature")
 
-    controller = Controller.from_port(port=control_port)
+    controller = Controller.from_port(address=host, port=port)
     controller.authenticate(password=password)
     hs = controller.create_ephemeral_hidden_service({service_port: local_port}, await_publication=True)
     onion = f"{hs.service_id}.onion"


### PR DESCRIPTION
## Summary
- add '/tor' admin route handling ENABLE_TOR and control port variables
- allow Tor service startup based on ENABLE_TOR
- update tor_service.py to use new environment variables
- revise tests for new env variables
- document Tor configuration in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684095686a388323bfdc7d61c9bb8905