### PR TITLE
Improve env loading

### DIFF
--- a/admin_app.py
+++ b/admin_app.py
@@ -8,12 +8,26 @@ from flask import (
     render_template_string,
 )
 
-from db import create_app, db, Product
-
-app = create_app()
 ADMIN_HOST = os.getenv("ADMIN_HOST", "127.0.0.1")
 ADMIN_PORT = int(os.getenv("ADMIN_PORT", "8000"))
 ENV_FILE = os.getenv("ENV_FILE", os.path.join(os.path.dirname(__file__), ".env"))
+
+
+def load_env(path: str | None = None) -> None:
+    """Load variables from a .env file into ``os.environ`` if not already set."""
+    env_path = path or ENV_FILE
+    if not os.path.exists(env_path):
+        return
+    with open(env_path) as f:
+        for line in f:
+            if "=" in line and not line.strip().startswith("#"):
+                key, value = line.strip().split("=", 1)
+                os.environ.setdefault(key, value)
+
+from db import create_app, db, Product
+
+load_env()
+app = create_app()
 
 
 def update_env_var(name: str, value: str) -> None:

--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from aiogram import Bot, Dispatcher, types
 from aiogram.filters import Command
 from aiogram.fsm.context import FSMContext
@@ -9,11 +10,24 @@ from aiogram import F
 from db import create_app, SessionLocal, User
 
 
+def load_env(path: str | None = None) -> None:
+    """Load variables from a .env file into ``os.environ`` if not already set."""
+    env_path = path or os.getenv("ENV_FILE", str(Path(__file__).with_name(".env")))
+    if not os.path.exists(env_path):
+        return
+    with open(env_path) as f:
+        for line in f:
+            if "=" in line and not line.strip().startswith("#"):
+                key, value = line.strip().split("=", 1)
+                os.environ.setdefault(key, value)
+
+
 class LangStates(StatesGroup):
     choose = State()
 
 
 def get_bot_token():
+    load_env()
     token = os.getenv("BOT_TOKEN")
     if not token:
         raise RuntimeError("BOT_TOKEN environment variable missing")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# test package

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,0 +1,16 @@
+import os
+import importlib
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_bot_token_from_env_file(tmp_path, monkeypatch):
+    env = tmp_path / '.env'
+    env.write_text('BOT_TOKEN=123456:ABC\n')
+    monkeypatch.setenv('ENV_FILE', str(env))
+    if 'bot' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('bot'))
+    import bot
+    assert bot.get_bot_token() == '123456:ABC'


### PR DESCRIPTION
## Summary
- load .env automatically in `bot.py` and `admin_app.py`
- add regression test for reading the bot token from the env file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840a56ac5008323a59a2b681ff66da6