### PR TITLE
Enable webhook mode for Telegram bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ die folgenden Variablen enthalten:
 * `DATABASE_URL` – optionale Datenbank-URL (Standard: `sqlite:///db.sqlite3`)
 * `ADMIN_HOST` – Hostname/IP für die Admin-GUI (Standard: `127.0.0.1`)
 * `ADMIN_PORT` – Port der Admin-GUI (Standard: `8000`)
+* `WEBHOOK_URL` – HTTPS-URL für Telegram-Webhooks (optional)
+* `WEBHOOK_HOST` – Hostname/IP für den Webhook-Server (Standard: `0.0.0.0`)
+* `WEBHOOK_PORT` – Port für den Webhook-Server (Standard: `8080`)
+* `WEBHOOK_PATH` – Pfad der Webhook-Route (Standard: `/webhook`)
 
 
 Die Werte können beispielsweise in einer `.env`-Datei gespeichert werden.
@@ -150,6 +154,10 @@ The systemd services load their configuration from the `.env` file. It must cont
 * `DATABASE_URL` – optional database URL (default: `sqlite:///db.sqlite3`)
 * `ADMIN_HOST` – Hostname/IP for the admin GUI (default: `127.0.0.1`)
 * `ADMIN_PORT` – Port of the admin GUI (default: `8000`)
+* `WEBHOOK_URL` – HTTPS URL for Telegram webhooks (optional)
+* `WEBHOOK_HOST` – Hostname/IP for the webhook server (default: `0.0.0.0`)
+* `WEBHOOK_PORT` – Port for the webhook server (default: `8080`)
+* `WEBHOOK_PATH` – Path for the webhook route (default: `/webhook`)
 * `ENABLE_TOR` – set to `1` to expose the admin GUI via Tor
 * `TOR_CONTROL_HOST` – host of the Tor control port (default: `127.0.0.1`)
 * `TOR_CONTROL_PORT` – port of the Tor control port (default: `9051`)

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,52 @@
+import importlib
+import os
+import sys
+import asyncio
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import aiogram
+from aiohttp import web
+
+
+def test_webhook_mode(monkeypatch):
+    monkeypatch.setenv('BOT_TOKEN', '123456:TEST')
+    monkeypatch.setenv('WEBHOOK_URL', 'https://example.com/hook')
+    monkeypatch.setenv('SECRET_KEY', 'test')
+    monkeypatch.setenv('ADMIN_USER', 'admin')
+    monkeypatch.setenv('ADMIN_PASS', 'pass')
+
+    calls = {}
+
+    async def fake_set_webhook(self, url):
+        calls['set'] = url
+
+    async def fake_delete_webhook(self):
+        calls['delete'] = True
+
+    def fake_run_app(app, host=None, port=None, loop=None):
+        calls['run'] = (host, port)
+        for cb in app.on_startup:
+            loop.run_until_complete(cb(app))
+        for cb in app.on_shutdown:
+            loop.run_until_complete(cb(app))
+
+    monkeypatch.setattr(aiogram.Bot, 'set_webhook', fake_set_webhook)
+    monkeypatch.setattr(aiogram.Bot, 'delete_webhook', fake_delete_webhook)
+    monkeypatch.setattr(web, 'run_app', fake_run_app)
+
+    if 'bot' in sys.modules:
+        importlib.reload(sys.modules['bot'])
+    else:
+        importlib.import_module('bot')
+
+    import bot
+    monkeypatch.setattr(bot, 'create_app', lambda: None)
+
+    bot.main()
+
+    assert calls['set'] == 'https://example.com/hook'
+    assert calls['delete'] is True
+    assert calls['run'] == ('0.0.0.0', 8080)
+


### PR DESCRIPTION
## Summary
- support webhook-based bot operation via new `WEBHOOK_*` env vars
- document webhook configuration in English and German README sections
- test webhook mode through new unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840bf4a217c8323893945bb2cc45966