### PR TITLE
Add shipping cost management

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ diese Einstellung für den Nutzer.
 * Erste Menü-Ausgabe "Wähle ein Produkt" bzw. "Choose a product" je nach Sprache.
 * Admin-Login (Benutzername und Passwort über `ADMIN_USER` und `ADMIN_PASS`).
 * Produktverwaltung mit Name, Preis und Beschreibung.
+* Verwaltung von Versandkosten pro Land.
 * GUI läuft lokal auf Port 8000.
 * Neue Route `/tor` ermöglicht das Steuern des Tor-Dienstes über die
   Variablen `ENABLE_TOR`, `TOR_CONTROL_HOST`, `TOR_CONTROL_PORT` und
@@ -124,6 +125,7 @@ This project contains a simple Telegram bot and an admin interface for managing 
 * The first menu shows "Wähle ein Produkt" or "Choose a product" depending on the chosen language.
 * Admin login using the username and password from `ADMIN_USER` and `ADMIN_PASS`.
 * Manage products with name, price and description.
+* Manage shipping costs per country.
 * The GUI runs locally on port 8000.
 * New `/tor` route allows controlling Tor using the `ENABLE_TOR`,
   `TOR_CONTROL_HOST`, `TOR_CONTROL_PORT` and `TOR_CONTROL_PASS`

--- a/bot.py
+++ b/bot.py
@@ -10,7 +10,7 @@ from aiogram.types import ReplyKeyboardMarkup, KeyboardButton
 from aiogram import F
 from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_application
 
-from db import create_app, SessionLocal, User
+from db import create_app, SessionLocal, User, ShippingCost
 
 
 def load_env(path: str | None = None) -> None:
@@ -43,6 +43,10 @@ class LangStates(StatesGroup):
     choose = State()
 
 
+class CountryStates(StatesGroup):
+    choose = State()
+
+
 def get_bot_token():
     load_env()
     token = os.getenv("BOT_TOKEN")
@@ -63,11 +67,29 @@ async def cmd_start(message: types.Message, state: FSMContext):
             kb = ReplyKeyboardMarkup(keyboard=[
                 [KeyboardButton(text="Deutsch"), KeyboardButton(text="English")]
             ], resize_keyboard=True)
-            await message.answer("Choose your language / Wähle deine Sprache", reply_markup=kb)
+            await message.answer(
+                "Choose your language / Wähle deine Sprache", reply_markup=kb
+            )
             await state.set_state(LangStates.choose)
-        else:
-            greeting = "W\u00e4hle ein Produkt" if user.language == "de" else "Choose a product"
-            await message.answer(greeting)
+            return
+
+        if not user.country:
+            countries = (
+                session.query(ShippingCost.country)
+                .order_by(ShippingCost.country)
+                .all()
+            )
+            if countries:
+                kb = ReplyKeyboardMarkup(
+                    keyboard=[[KeyboardButton(text=c.country)] for c in countries],
+                    resize_keyboard=True,
+                )
+                await message.answer("Choose country", reply_markup=kb)
+                await state.set_state(CountryStates.choose)
+                return
+
+        greeting = "W\u00e4hle ein Produkt" if user.language == "de" else "Choose a product"
+        await message.answer(greeting)
 
 
 @dp.message(LangStates.choose)
@@ -80,6 +102,36 @@ async def set_language(message: types.Message, state: FSMContext):
             session.add(user)
         else:
             user.language = lang
+        session.commit()
+
+        countries = (
+            session.query(ShippingCost.country).order_by(ShippingCost.country).all()
+        )
+
+    if countries:
+        kb = ReplyKeyboardMarkup(
+            keyboard=[[KeyboardButton(text=c.country)] for c in countries],
+            resize_keyboard=True,
+        )
+        await state.set_state(CountryStates.choose)
+        await message.answer("Choose country", reply_markup=kb)
+    else:
+        await state.clear()
+        greeting = "W\u00e4hle ein Produkt" if lang == "de" else "Choose a product"
+        await message.answer(greeting, reply_markup=types.ReplyKeyboardRemove())
+
+
+@dp.message(CountryStates.choose)
+async def set_country(message: types.Message, state: FSMContext):
+    country = message.text.strip()
+    with SessionLocal() as session:
+        user = session.query(User).filter_by(telegram_id=message.from_user.id).first()
+        if not user:
+            user = User(telegram_id=message.from_user.id, country=country)
+            session.add(user)
+        else:
+            user.country = country
+        lang = user.language or 'en'
         session.commit()
     await state.clear()
     greeting = "W\u00e4hle ein Produkt" if lang == "de" else "Choose a product"

--- a/db.py
+++ b/db.py
@@ -24,6 +24,14 @@ class User(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     telegram_id = db.Column(db.Integer, unique=True)
     language = db.Column(db.String(10))
+    country = db.Column(db.String(50))
+
+
+class ShippingCost(db.Model):
+    __tablename__ = "shipping_costs"
+    id = db.Column(db.Integer, primary_key=True)
+    country = db.Column(db.String(50), unique=True)
+    cost = db.Column(db.Float)
 
 
 def get_secret_key():

--- a/templates/product_list.html
+++ b/templates/product_list.html
@@ -1,4 +1,5 @@
 <a href="{{ url_for('add_product') }}">Neues Produkt</a>
+<a href="{{ url_for('shipping') }}">Shipping</a>
 <ul>
 {% for p in products %}
     <li>

--- a/templates/shipping.html
+++ b/templates/shipping.html
@@ -1,0 +1,13 @@
+<h2>Shipping Costs</h2>
+{% if message %}<p>{{ message }}</p>{% endif %}
+<form method="post">
+    <input name="country" placeholder="Country">
+    <input name="cost" type="number" step="0.01" placeholder="Cost">
+    <button type="submit">Save</button>
+</form>
+<ul>
+{% for c in costs %}
+    <li>{{ c.country }} - {{ c.cost }} € <a href="{{ url_for('delete_shipping', sid=c.id) }}">Delete</a></li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('product_list') }}">Back</a>

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+import importlib
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+def test_shipping_admin(tmp_path, monkeypatch):
+    env_file = tmp_path / '.env'
+    monkeypatch.setenv('ENV_FILE', str(env_file))
+    monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/test.sqlite3')
+    monkeypatch.setenv('SECRET_KEY', 'test')
+    monkeypatch.setenv('ADMIN_USER', 'admin')
+    monkeypatch.setenv('ADMIN_PASS', 'pass')
+
+    if 'db' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('db'))
+    if 'admin_app' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('admin_app'))
+    admin_app = importlib.import_module('admin_app')
+    app = admin_app.app
+    client = app.test_client()
+
+    client.post('/login', data={'username': 'admin', 'password': 'pass'})
+
+    resp = client.post('/shipping', data={'country': 'DE', 'cost': '5.0'})
+    assert resp.status_code == 200
+
+    from db import ShippingCost
+    with app.app_context():
+        entry = ShippingCost.query.filter_by(country='DE').first()
+        assert entry is not None
+        assert entry.cost == 5.0


### PR DESCRIPTION
## Summary
- manage shipping costs per country in the admin interface
- store shipping country for users and prompt for it when starting the bot
- add SQLAlchemy models for shipping costs
- add tests for the new shipping interface
- document shipping management in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840d715a2848323bc8d71ff43d77316