### PR TITLE
Add CSRF, bcrypt and rate limiting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,8 @@ stem
 
 python-dotenv
 
+Flask-WTF
+Flask-Limiter
+bcrypt
+
 pytest

--- a/setup.py
+++ b/setup.py
@@ -120,9 +120,14 @@ def main(argv: list[str] | None = None) -> None:
     python_exe, pip_exe = create_venv()
     install_deps(pip_exe)
 
+    import bcrypt
+
     env = load_env_file()
-    for var in ["BOT_TOKEN", "ADMIN_USER", "ADMIN_PASS", "SECRET_KEY"]:
+    for var in ["BOT_TOKEN", "ADMIN_USER", "SECRET_KEY"]:
         env[var] = env.get(var) or prompt_env(var)
+    password = env.get("ADMIN_PASS") or prompt_env("ADMIN_PASS")
+    env["ADMIN_PASS_HASH"] = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    env.pop("ADMIN_PASS", None)
 
     write_env_file(env)
 

--- a/setup.sh
+++ b/setup.sh
@@ -43,7 +43,16 @@ prompt_var() {
 
 prompt_var BOT_TOKEN "BOT_TOKEN"
 prompt_var ADMIN_USER "Admin username"
+
 prompt_var ADMIN_PASS "Admin password"
+HASHED=$(python3 - <<'EOF'
+import bcrypt, os
+print(bcrypt.hashpw(os.environ['ADMIN_PASS'].encode(), bcrypt.gensalt()).decode())
+EOF
+)
+write_env ADMIN_PASS_HASH "$HASHED"
+unset ADMIN_PASS
+
 prompt_var SECRET_KEY "Flask SECRET_KEY"
 
 echo "[Unit]" > bot.service

--- a/tests/test_admin_login.py
+++ b/tests/test_admin_login.py
@@ -9,8 +9,10 @@ def test_admin_login(tmp_path, monkeypatch):
     db_path = tmp_path / 'test.sqlite3'
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_path}')
     monkeypatch.setenv('SECRET_KEY', 'test')
+    import bcrypt
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS', 'pass')
+    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
+    monkeypatch.setenv('FLASK_ENV', 'test')
 
     if 'db' in importlib.sys.modules:
         importlib.reload(importlib.import_module('db'))

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -10,8 +10,10 @@ def test_shipping_admin(tmp_path, monkeypatch):
     monkeypatch.setenv('ENV_FILE', str(env_file))
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/test.sqlite3')
     monkeypatch.setenv('SECRET_KEY', 'test')
+    import bcrypt
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS', 'pass')
+    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
+    monkeypatch.setenv('FLASK_ENV', 'test')
 
     if 'db' in importlib.sys.modules:
         importlib.reload(importlib.import_module('db'))

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -11,12 +11,14 @@ def test_tor_settings(tmp_path, monkeypatch):
     monkeypatch.setenv('ENV_FILE', str(env_file))
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/test.sqlite3')
     monkeypatch.setenv('SECRET_KEY', 'test')
+    import bcrypt
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS', 'pass')
+    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
     monkeypatch.setenv('ENABLE_TOR', '0')
     monkeypatch.setenv('TOR_CONTROL_HOST', 'localhost')
     monkeypatch.setenv('TOR_CONTROL_PORT', '9051')
     monkeypatch.setenv('TOR_CONTROL_PASS', 'passw')
+    monkeypatch.setenv('FLASK_ENV', 'test')
 
     if 'db' in importlib.sys.modules:
         importlib.reload(importlib.import_module('db'))

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -13,9 +13,11 @@ from aiohttp import web
 def test_webhook_mode(monkeypatch):
     monkeypatch.setenv('BOT_TOKEN', '123456:TEST')
     monkeypatch.setenv('WEBHOOK_URL', 'https://example.com/hook')
+    import bcrypt
     monkeypatch.setenv('SECRET_KEY', 'test')
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS', 'pass')
+    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
+    monkeypatch.setenv('FLASK_ENV', 'test')
 
     calls = {}
 


### PR DESCRIPTION
## Summary
- secure admin logins with bcrypt hashed passwords
- enable CSRF protection and rate limiting
- add session timeout config
- adjust setup scripts to store password hashes
- update tests for hashed passwords

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416dbb4600832396cb8ba4c2b590fe