### PR TITLE
Fix product list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Nach dem Start ist der Bot über Telegram erreichbar (Token per
 Die Skripte schreiben Logdateien `bot.log` und `admin.log`, die bei Fehlern
 hilfreich sind.
 Nach dem Setup wird zudem eine Datei `onion_url.txt` mit der Tor-Adresse erzeugt,
-die im Terminal ausgegeben wird.
+die im Terminal ausgegeben wird. Stelle sicher, dass der Dienst `tor` läuft und
+ein ControlPort (standardmäßig `9051`) erreichbar ist, sonst erscheint die Meldung
+`Tor onion address not found`.
 
 ### So prüfst du dein Setup
 
@@ -200,7 +202,7 @@ Python 3 is required. On some systems the executable is named `python3`.
 After starting, the bot is reachable via Telegram (set the token with the `BOT_TOKEN` environment variable) and the admin GUI is available at [http://localhost:8000](http://localhost:8000).
 Log files `bot.log` and `admin.log` are created to help with troubleshooting.
 
-The setup script also prints a Tor address stored in `onion_url.txt` to reach the GUI from anywhere.
+The setup script also prints a Tor address stored in `onion_url.txt` to reach the GUI from anywhere. Ensure the `tor` service is running with a reachable control port (default `9051`), otherwise you will see `Tor onion address not found`.
 
 ### Verify your setup
 

--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,7 @@ from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_applicati
 from aiohttp import web
 
 from config import load_env, setup_logging
-from db import create_app, SessionLocal, User, ShippingCost
+from db import create_app, SessionLocal, User, ShippingCost, Product
 from currency import convert, COUNTRY_CURRENCY
 
 
@@ -40,6 +40,19 @@ GREETINGS = {
     "tr": "Bir \u00fcr\u00fcn se\u00e7",
     "ru": "\u0412\u044b\u0431\u0435\u0440\u0438\u0442\u0435 \u0442\u043e\u0432\u0430\u0440",
 }
+
+
+async def send_product_list(message: types.Message) -> None:
+    """Send a simple list of available products."""
+    with SessionLocal() as session:
+        products = session.query(Product).order_by(Product.id).all()
+
+    if not products:
+        await message.answer("No products available")
+        return
+
+    lines = [f"{p.name} - {p.price:.2f} \u20ac" for p in products]
+    await message.answer("\n".join(lines))
 
 
 def get_bot_token() -> str:
@@ -91,6 +104,7 @@ async def cmd_start(message: types.Message, state: FSMContext) -> None:
 
         greeting = GREETINGS.get(user.language, "Choose a product")
         await message.answer(greeting)
+        await send_product_list(message)
 
 
 @dp.message(LangStates.choose)
@@ -160,6 +174,7 @@ async def set_country(message: types.Message, state: FSMContext) -> None:
         await message.answer(f"Shipping to {country}: {cost_text}")
     greeting = GREETINGS.get(lang, "Choose a product")
     await message.answer(greeting, reply_markup=types.ReplyKeyboardRemove())
+    await send_product_list(message)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/setup.sh
+++ b/setup.sh
@@ -90,8 +90,7 @@ prompt_var TOR_CONTROL_HOST "Tor control host" "127.0.0.1"
 prompt_var TOR_CONTROL_PORT "Tor control port" "9051"
 prompt_var TOR_CONTROL_PASS "Tor control password"
 
-# enable Tor by default and configure the file containing the onion URL
-write_env ENABLE_TOR 1
+# file containing the onion URL if Tor is enabled
 ONION_FILE="$REPO_DIR/onion_url.txt"
 write_env ONION_FILE "$ONION_FILE"
 
@@ -141,7 +140,7 @@ echo "Telegram Bot started. Configure it via Telegram."
 echo "Admin GUI available at http://localhost:8000"
 
 # wait for Tor hidden service information if available
-if [ -n "$ONION_FILE" ]; then
+if [ "$ENABLE_TOR" = "1" ] && [ -n "$ONION_FILE" ]; then
     echo -n "Waiting for Tor address..."
     for _ in {1..10}; do
         if [ -f "$ONION_FILE" ]; then

--- a/tests/test_product_list.py
+++ b/tests/test_product_list.py
@@ -1,0 +1,61 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+class DummyUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+
+class DummyMessage:
+    def __init__(self, text, user_id=1):
+        self.text = text
+        self.from_user = DummyUser(user_id)
+        self.responses = []
+
+    async def answer(self, text, reply_markup=None):
+        self.responses.append(text)
+
+
+class DummyState:
+    async def set_state(self, state):
+        self.state = state
+
+async def call_handler(handler, message, state):
+    await handler(message, state)
+
+
+def test_cmd_start_lists_products(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    monkeypatch.setenv("ENV_FILE", str(env_file))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/test.sqlite3")
+    monkeypatch.setenv("BOT_TOKEN", "123:TEST")
+    monkeypatch.setenv("SECRET_KEY", "test")
+
+    if "db" in sys.modules:
+        importlib.reload(sys.modules["db"])
+    else:
+        importlib.import_module("db")
+    import db
+    app = db.create_app()
+    with app.app_context():
+        db.db.create_all()
+        db.db.session.add(db.User(telegram_id=1, language="de", country="DE"))
+        db.db.session.add(db.Product(name="Prod1", price=1.0, description="Desc"))
+        db.db.session.commit()
+
+    if "bot" in sys.modules:
+        importlib.reload(sys.modules["bot"])
+    else:
+        importlib.import_module("bot")
+    import bot
+
+    msg = DummyMessage("/start")
+    state = DummyState()
+    asyncio.run(call_handler(bot.cmd_start, msg, state))
+
+    assert any("Prod1" in r for r in msg.responses)


### PR DESCRIPTION
## Summary
- show available products in the Telegram bot
- test that `/start` includes product list
- honor user option when enabling Tor
- explain Tor requirement in the docs

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842003ae4108323b1ff5bcc276e58e7