### PR TITLE
Update README about log locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ Nach dem Start ist der Bot über Telegram erreichbar (Token per
 `BOT_TOKEN`-Umgebungsvariable setzen) und die Admin-GUI unter
 [http://localhost:8000](http://localhost:8000).
 Die Skripte schreiben Logdateien `bot.log` und `admin.log`, die bei Fehlern
-hilfreich sind.
+hilfreich sind. Die Dateien werden in dem Verzeichnis abgelegt, das in den
+systemd-Service-Dateien als `WorkingDirectory` angegeben ist.
 Nach dem Setup wird zudem eine Datei `onion_url.txt` mit der Tor-Adresse erzeugt,
 die im Terminal ausgegeben wird. Stelle sicher, dass der Dienst `tor` läuft und
 ein ControlPort (standardmäßig `9051`) erreichbar ist, sonst erscheint die Meldung
@@ -201,6 +202,8 @@ Python 3 is required. On some systems the executable is named `python3`.
 
 After starting, the bot is reachable via Telegram (set the token with the `BOT_TOKEN` environment variable) and the admin GUI is available at [http://localhost:8000](http://localhost:8000).
 Log files `bot.log` and `admin.log` are created to help with troubleshooting.
+They are written to the directory configured as `WorkingDirectory` in the
+service files.
 
 The setup script also prints a Tor address stored in `onion_url.txt` to reach the GUI from anywhere. Ensure the `tor` service is running with a reachable control port (default `9051`), otherwise you will see `Tor onion address not found`.
 


### PR DESCRIPTION
## Summary
- clarify where `bot.log` and `admin.log` are written

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_68420cced7408323bc7cac41ff05e800