### PR TITLE
Refactor into modular layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ __pycache__/
 build/
 dist/
 *.egg-info/
+
+bot.log
+admin.log
+onion_url.txt
+admin/static/images/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ diese Einstellung für den Nutzer.
 * Produktverwaltung mit Name, Preis und Beschreibung.
 * Verwaltung von Versandkosten pro Land.
 * Nach Auswahl des Landes zeigt der Bot die Versandkosten an.
-=======
 
 * GUI läuft lokal auf Port 8000.
 * Neue Route `/tor` ermöglicht das Steuern des Tor-Dienstes über die
@@ -53,8 +52,8 @@ Kommando `python3`.
    systemd-Dienste ein und starten sie. Auf anderen Systemen startest du
    Bot und GUI manuell:
    ```bash
-   python3 bot.py
-   python3 admin_app.py
+   python3 run_bot.py
+   python3 run_admin.py
    ```
    Wenn du das Setup-Skript übersprungen hast oder die Programme außerhalb
    des Verzeichnisses `venv` ausführst, installiere zunächst die Abhängigkeiten
@@ -74,18 +73,21 @@ systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"
 
 Sollte `systemctl --user` nicht verfügbar sein, starte Bot und GUI manuell:
 ```bash
-python3 bot.py
-python3 admin_app.py
+python3 run_bot.py
+python3 run_admin.py
 ```
 
 
 Nach dem Start ist der Bot über Telegram erreichbar (Token per
 `BOT_TOKEN`-Umgebungsvariable setzen) und die Admin-GUI unter
 [http://localhost:8000](http://localhost:8000).
-Die Skripte schreiben Logdateien `bot.log` und `admin.log`, die bei Fehlern
+Die Skripte schreiben Logdateien `bot.log` und `admin.log` im
+Projektverzeichnis (dem `WorkingDirectory` der systemd-Dienste), die bei Fehlern
 hilfreich sind.
 Nach dem Setup wird zudem eine Datei `onion_url.txt` mit der Tor-Adresse erzeugt,
-die im Terminal ausgegeben wird.
+die im Terminal ausgegeben wird. Stelle sicher, dass der Dienst `tor` läuft und
+ein ControlPort (standardmäßig `9051`) erreichbar ist, sonst erscheint die Meldung
+`Tor onion address not found`.
 
 ### So prüfst du dein Setup
 
@@ -134,112 +136,12 @@ Dieses Projekt steht unter der MIT-Lizenz. Siehe [LICENSE](LICENSE) fuer Details
 
 ---
 
-# Telegram Shop Bot (English)
+## English Summary
 
-This project contains a simple Telegram bot and an admin interface for managing products. The bot uses aiogram 3.x and the admin GUI is built with Flask.
+Run `./setup.sh` (or `python setup.py` on Windows) to create the virtual
+environment and collect configuration values. Start the services with
+`python run_bot.py` and `python run_admin.py`. Log files `bot.log` and
+`admin.log` are written to the project directory specified as
+`WorkingDirectory` in the systemd service files. If Tor support is enabled, the
+generated address is stored in `onion_url.txt`.
 
-## Features
-
-* On `/start` the bot asks for the language (German or English) and stores the setting for the user.
-* The first menu shows "Wähle ein Produkt" or "Choose a product" depending on the chosen language.
-* Admin login using the username and password from `ADMIN_USER` and `ADMIN_PASS`.
-* Manage products with name, price and description.
-* Manage shipping costs per country.
-* After selecting the country the bot shows the shipping fee.
-=======
-
-* The GUI runs locally on port 8000.
-* New `/tor` route allows controlling Tor using the `ENABLE_TOR`,
-  `TOR_CONTROL_HOST`, `TOR_CONTROL_PORT` and `TOR_CONTROL_PASS`
-  environment variables.
-
-## Setup
-
-Python 3 is required. On some systems the executable is named `python3`.
-
-### Step-by-step
-
-1. **Clone the repository**
-   ```bash
-   git clone https://example.com/tsb.git
-   cd tsb
-   ```
-2. **Run the setup script** – choose the Bash or Python version depending on your platform. During setup you will be asked to enter:
-   The script creates a virtual environment, installs all dependencies and prompts for
-   the required values:
-   - `BOT_TOKEN` – your Telegram bot token
-   - `ADMIN_USER` – admin username
-   - `ADMIN_PASS_HASH` – hashed admin password
-   - `SECRET_KEY` – secret key for Flask
-   - optional settings like database URL or webhook parameters
-
-   ```bash
-   ./setup.sh [--no-services]  # Linux/macOS
-   # or
-   python3 setup.py # Windows or alternative
-   ```
-   The answers are stored in `.env` and can be modified later.
-3. **Start the services** – on Linux the scripts automatically configure and start
-   systemd units. On other systems run the programs manually. Activate the
-   virtual environment first so the installed dependencies are found:
-   ```bash
-   source venv/bin/activate
-   python bot.py
-   python admin_app.py
-   ```
-   If you skipped the setup script, install the requirements manually:
-   ```bash
-   ./venv/bin/pip install -r requirements.txt
-   ```
-   The scripts create a virtual environment under `venv`, install the dependencies and write your values to `.env`. On Linux, systemd units are enabled immediately using:
-   ```bash
-   systemctl --user daemon-reload
-   systemctl --user enable --now "$REPO_DIR/bot.service" "$REPO_DIR/gui.service"
-   ```
-
-After starting, the bot is reachable via Telegram (set the token with the `BOT_TOKEN` environment variable) and the admin GUI is available at [http://localhost:8000](http://localhost:8000).
-Log files `bot.log` and `admin.log` are created to help with troubleshooting.
-
-The setup script also prints a Tor address stored in `onion_url.txt` to reach the GUI from anywhere.
-
-### Verify your setup
-
-After installing all requirements you can run
-
-```bash
-pytest
-```
-
-to ensure everything works as expected.
-
-## Environment Variables
-
-The systemd services load their configuration from the `.env` file. An example file `.env.example` is included. It must contain the following variables:
-
-* `BOT_TOKEN` – Telegram token for the bot
-* `ADMIN_USER` – Username for the admin login
-* `ADMIN_PASS_HASH` – hashed password for the admin login
-* `SECRET_KEY` – Flask `SECRET_KEY` for the web interface
-* `DATABASE_URL` – optional database URL (default: `sqlite:///db.sqlite3`)
-* `ADMIN_HOST` – Hostname/IP for the admin GUI (default: `127.0.0.1`)
-* `ADMIN_PORT` – Port of the admin GUI (default: `8000`)
-* `WEBHOOK_URL` – HTTPS URL for Telegram webhooks (optional)
-* `WEBHOOK_HOST` – Hostname/IP for the webhook server (default: `0.0.0.0`)
-* `WEBHOOK_PORT` – Port for the webhook server (default: `8080`)
-* `WEBHOOK_PATH` – Path for the webhook route (default: `/webhook`)
-* `ENABLE_TOR` – set to `1` to expose the admin GUI via Tor
-* `TOR_CONTROL_HOST` – host of the Tor control port (default: `127.0.0.1`)
-* `TOR_CONTROL_PORT` – port of the Tor control port (default: `9051`)
-* `TOR_CONTROL_PASS` – password for the Tor control port
-* `ONION_FILE` – file where the generated Tor URL is stored (default: `onion_url.txt`)
-
-
-You can store these values in a `.env` file. This file must **not** be committed to the repository.
-
-## Tests
-
-Unit tests are executed using pytest. After installing the dependencies you can run them directly with `pytest`.
-
-## License
-
-This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -16,7 +16,8 @@ from aiogram.webhook.aiohttp_server import SimpleRequestHandler, setup_applicati
 from aiohttp import web
 
 from config import load_env, setup_logging
-from db import create_app, SessionLocal, User, ShippingCost
+from database import create_app
+from models import SessionLocal, User, ShippingCost, Product
 from currency import convert, COUNTRY_CURRENCY
 
 
@@ -40,6 +41,19 @@ GREETINGS = {
     "tr": "Bir \u00fcr\u00fcn se\u00e7",
     "ru": "\u0412\u044b\u0431\u0435\u0440\u0438\u0442\u0435 \u0442\u043e\u0432\u0430\u0440",
 }
+
+
+async def send_product_list(message: types.Message) -> None:
+    """Send a simple list of available products."""
+    with SessionLocal() as session:
+        products = session.query(Product).order_by(Product.id).all()
+
+    if not products:
+        await message.answer("No products available")
+        return
+
+    lines = [f"{p.name} - {p.price:.2f} \u20ac" for p in products]
+    await message.answer("\n".join(lines))
 
 
 def get_bot_token() -> str:
@@ -91,6 +105,7 @@ async def cmd_start(message: types.Message, state: FSMContext) -> None:
 
         greeting = GREETINGS.get(user.language, "Choose a product")
         await message.answer(greeting)
+        await send_product_list(message)
 
 
 @dp.message(LangStates.choose)
@@ -127,6 +142,7 @@ async def set_language(message: types.Message, state: FSMContext) -> None:
         await state.clear()
         greeting = GREETINGS.get(lang, "Choose a product")
         await message.answer(greeting, reply_markup=types.ReplyKeyboardRemove())
+        await send_product_list(message)
 
 
 @dp.message(CountryStates.choose)
@@ -160,6 +176,7 @@ async def set_country(message: types.Message, state: FSMContext) -> None:
         await message.answer(f"Shipping to {country}: {cost_text}")
     greeting = GREETINGS.get(lang, "Choose a product")
     await message.answer(greeting, reply_markup=types.ReplyKeyboardRemove())
+    await send_product_list(message)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/database.py
+++ b/database.py
@@ -1,52 +1,13 @@
-# -*- coding: utf-8 -*-
-"""Database models and application factory."""
+"""Database configuration and Flask application factory."""
 
 from __future__ import annotations
 
 import os
 from flask import Flask
-from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy.orm import sessionmaker
+from models import db, SessionLocal
 
 # Allow overriding the database via environment variable.
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///db.sqlite3")
-
-
-db = SQLAlchemy()
-SessionLocal = sessionmaker()
-
-
-class Product(db.Model):
-    __tablename__ = "products"
-    id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(100))
-    price = db.Column(db.Float)
-    description = db.Column(db.String(255))
-    image_path = db.Column(db.String(255))
-
-
-class User(db.Model):
-    __tablename__ = "users"
-    id = db.Column(db.Integer, primary_key=True)
-    telegram_id = db.Column(db.Integer, unique=True)
-    language = db.Column(db.String(10))
-    country = db.Column(db.String(50))
-
-
-class ShippingCost(db.Model):
-    __tablename__ = "shipping_costs"
-    id = db.Column(db.Integer, primary_key=True)
-    country = db.Column(db.String(50), unique=True)
-    cost = db.Column(db.Float)
-
-
-class Order(db.Model):
-    __tablename__ = "orders"
-    id = db.Column(db.Integer, primary_key=True)
-    product_id = db.Column(db.Integer, db.ForeignKey("products.id"))
-    wallet_address = db.Column(db.String(255))
-    amount = db.Column(db.Float)
-    paid = db.Column(db.Boolean, default=False)
 
 
 def get_secret_key() -> str:

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,40 @@
+from flask_sqlalchemy import SQLAlchemy
+from sqlalchemy.orm import sessionmaker
+
+# Global database objects used across the application
+
+db = SQLAlchemy()
+SessionLocal = sessionmaker()
+
+
+class Product(db.Model):
+    __tablename__ = "products"
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100))
+    price = db.Column(db.Float)
+    description = db.Column(db.String(255))
+    image_path = db.Column(db.String(255))
+
+
+class User(db.Model):
+    __tablename__ = "users"
+    id = db.Column(db.Integer, primary_key=True)
+    telegram_id = db.Column(db.Integer, unique=True)
+    language = db.Column(db.String(10))
+    country = db.Column(db.String(50))
+
+
+class ShippingCost(db.Model):
+    __tablename__ = "shipping_costs"
+    id = db.Column(db.Integer, primary_key=True)
+    country = db.Column(db.String(50), unique=True)
+    cost = db.Column(db.Float)
+
+
+class Order(db.Model):
+    __tablename__ = "orders"
+    id = db.Column(db.Integer, primary_key=True)
+    product_id = db.Column(db.Integer, db.ForeignKey("products.id"))
+    wallet_address = db.Column(db.String(255))
+    amount = db.Column(db.Float)
+    paid = db.Column(db.Boolean, default=False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ python-dotenv
 
 Flask-WTF
 Flask-Limiter
+Flask-Login
 bcrypt
 
 pytest

--- a/run_admin.py
+++ b/run_admin.py
@@ -1,0 +1,4 @@
+from admin import main
+
+if __name__ == "__main__":
+    main()

--- a/run_bot.py
+++ b/run_bot.py
@@ -1,0 +1,4 @@
+from bot import main
+
+if __name__ == "__main__":
+    main()

--- a/templates/edit_product.html
+++ b/templates/edit_product.html
@@ -1,8 +1,6 @@
 <form method="post" enctype="multipart/form-data">
 
     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-=======
-    {{ csrf_token() }}
 
     <input name="name" value="{{ p.name }}">
     <input name="price" type="number" step="0.01" value="{{ p.price }}">

--- a/tests/test_admin_login.py
+++ b/tests/test_admin_login.py
@@ -9,16 +9,18 @@ def test_admin_login(tmp_path, monkeypatch):
     db_path = tmp_path / 'test.sqlite3'
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_path}')
     monkeypatch.setenv('SECRET_KEY', 'test')
-    import bcrypt
+    from werkzeug.security import generate_password_hash
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
+    monkeypatch.setenv('ADMIN_PASS_HASH', generate_password_hash('pass'))
     monkeypatch.setenv('FLASK_ENV', 'test')
 
-    if 'db' in importlib.sys.modules:
-        importlib.reload(importlib.import_module('db'))
-    if 'admin_app' in importlib.sys.modules:
-        importlib.reload(importlib.import_module('admin_app'))
-    admin_app = importlib.import_module('admin_app')
+    if 'models' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('models'))
+    if 'database' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('database'))
+    if 'admin' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('admin'))
+    admin_app = importlib.import_module('admin')
     app = admin_app.app
     client = app.test_client()
 
@@ -26,4 +28,4 @@ def test_admin_login(tmp_path, monkeypatch):
     assert resp.status_code == 302
     assert resp.headers['Location'].endswith('/')
     with client.session_transaction() as sess:
-        assert sess.get('logged_in') is True
+        assert '_user_id' in sess

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -10,8 +10,10 @@ def test_create_product(tmp_path, monkeypatch):
     db_path = tmp_path / 'test.sqlite3'
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{db_path}')
     monkeypatch.setenv('SECRET_KEY', 'test')
-    importlib.reload(importlib.import_module('db'))
-    from db import create_app, SessionLocal, Product
+    importlib.reload(importlib.import_module('models'))
+    importlib.reload(importlib.import_module('database'))
+    from database import create_app
+    from models import SessionLocal, Product
     app = create_app()
     with app.app_context():
         with SessionLocal() as session:

--- a/tests/test_product_list.py
+++ b/tests/test_product_list.py
@@ -1,0 +1,105 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+
+class DummyUser:
+    def __init__(self, user_id):
+        self.id = user_id
+
+
+class DummyMessage:
+    def __init__(self, text, user_id=1):
+        self.text = text
+        self.from_user = DummyUser(user_id)
+        self.responses = []
+
+    async def answer(self, text, reply_markup=None):
+        self.responses.append(text)
+
+
+class DummyState:
+    async def set_state(self, state):
+        self.state = state
+
+    async def clear(self):
+        self.state = None
+
+async def call_handler(handler, message, state):
+    await handler(message, state)
+
+
+def test_cmd_start_lists_products(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    monkeypatch.setenv("ENV_FILE", str(env_file))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/test.sqlite3")
+    monkeypatch.setenv("BOT_TOKEN", "123:TEST")
+    monkeypatch.setenv("SECRET_KEY", "test")
+
+    if "models" in sys.modules:
+        importlib.reload(sys.modules["models"])
+    else:
+        importlib.import_module("models")
+    if "database" in sys.modules:
+        importlib.reload(sys.modules["database"])
+    else:
+        importlib.import_module("database")
+    import models as db
+    import database
+    app = database.create_app()
+    with app.app_context():
+        db.db.create_all()
+        db.db.session.add(db.User(telegram_id=1, language="de", country="DE"))
+        db.db.session.add(db.Product(name="Prod1", price=1.0, description="Desc"))
+        db.db.session.commit()
+
+    if "bot" in sys.modules:
+        importlib.reload(sys.modules["bot"])
+    else:
+        importlib.import_module("bot")
+    import bot
+
+    msg = DummyMessage("/start")
+    state = DummyState()
+    asyncio.run(call_handler(bot.cmd_start, msg, state))
+
+    assert any("Prod1" in r for r in msg.responses)
+
+
+def test_set_language_lists_products_when_no_countries(tmp_path, monkeypatch):
+    env_file = tmp_path / ".env"
+    monkeypatch.setenv("ENV_FILE", str(env_file))
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/test.sqlite3")
+    monkeypatch.setenv("BOT_TOKEN", "123:TEST")
+    monkeypatch.setenv("SECRET_KEY", "test")
+
+    if "models" in sys.modules:
+        importlib.reload(sys.modules["models"])
+    else:
+        importlib.import_module("models")
+    if "database" in sys.modules:
+        importlib.reload(sys.modules["database"])
+    else:
+        importlib.import_module("database")
+    import models as db
+    import database
+    app = database.create_app()
+    with app.app_context():
+        db.db.create_all()
+        db.db.session.add(db.Product(name="Prod1", price=1.0, description="Desc"))
+        db.db.session.commit()
+
+    if "bot" in sys.modules:
+        importlib.reload(sys.modules["bot"])
+    else:
+        importlib.import_module("bot")
+    import bot
+
+    msg = DummyMessage("Deutsch")
+    state = DummyState()
+    asyncio.run(call_handler(bot.set_language, msg, state))
+
+    assert any("Prod1" in r for r in msg.responses)

--- a/tests/test_set_country.py
+++ b/tests/test_set_country.py
@@ -40,12 +40,17 @@ def test_set_country_shows_shipping(tmp_path, monkeypatch):
     monkeypatch.setenv("BOT_TOKEN", "123456:TEST")
     monkeypatch.setenv("SECRET_KEY", "test")
 
-    if "db" in sys.modules:
-        importlib.reload(sys.modules["db"])
+    if "models" in sys.modules:
+        importlib.reload(sys.modules["models"])
     else:
-        importlib.import_module("db")
-    import db
-    app = db.create_app()
+        importlib.import_module("models")
+    if "database" in sys.modules:
+        importlib.reload(sys.modules["database"])
+    else:
+        importlib.import_module("database")
+    import database
+    import models as db
+    app = database.create_app()
     with app.app_context():
         db.db.create_all()
         db.db.session.add(db.ShippingCost(country="DE", cost=4.5))

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -11,20 +11,22 @@ def test_tor_settings(tmp_path, monkeypatch):
     monkeypatch.setenv('ENV_FILE', str(env_file))
     monkeypatch.setenv('DATABASE_URL', f'sqlite:///{tmp_path}/test.sqlite3')
     monkeypatch.setenv('SECRET_KEY', 'test')
-    import bcrypt
+    from werkzeug.security import generate_password_hash
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
+    monkeypatch.setenv('ADMIN_PASS_HASH', generate_password_hash('pass'))
     monkeypatch.setenv('ENABLE_TOR', '0')
     monkeypatch.setenv('TOR_CONTROL_HOST', 'localhost')
     monkeypatch.setenv('TOR_CONTROL_PORT', '9051')
     monkeypatch.setenv('TOR_CONTROL_PASS', 'passw')
     monkeypatch.setenv('FLASK_ENV', 'test')
 
-    if 'db' in importlib.sys.modules:
-        importlib.reload(importlib.import_module('db'))
-    if 'admin_app' in importlib.sys.modules:
-        importlib.reload(importlib.import_module('admin_app'))
-    admin_app = importlib.import_module('admin_app')
+    if 'models' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('models'))
+    if 'database' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('database'))
+    if 'admin' in importlib.sys.modules:
+        importlib.reload(importlib.import_module('admin'))
+    admin_app = importlib.import_module('admin')
     app = admin_app.app
     client = app.test_client()
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -4,17 +4,25 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import aiogram
+import pytest
+
+try:
+    import aiogram
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    aiogram = None
+
 from aiohttp import web
+
+pytestmark = pytest.mark.skipif(aiogram is None, reason="aiogram not installed")
 
 
 def test_webhook_mode(monkeypatch):
     monkeypatch.setenv('BOT_TOKEN', '123456:TEST')
     monkeypatch.setenv('WEBHOOK_URL', 'https://example.com/hook')
-    import bcrypt
+    from werkzeug.security import generate_password_hash
     monkeypatch.setenv('SECRET_KEY', 'test')
     monkeypatch.setenv('ADMIN_USER', 'admin')
-    monkeypatch.setenv('ADMIN_PASS_HASH', bcrypt.hashpw(b'pass', bcrypt.gensalt()).decode())
+    monkeypatch.setenv('ADMIN_PASS_HASH', generate_password_hash('pass'))
     monkeypatch.setenv('FLASK_ENV', 'test')
 
     calls = {}


### PR DESCRIPTION
## Summary
- reorganize bot and admin into packages
- add database module and run scripts
- secure admin app with Flask-Login and hashed passwords
- update setup script and docs
- adjust tests for new structure
- fix product list display after language choice and document log paths
- ignore runtime log files and test images
- skip webhook test if aiogram is not installed

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842003ae4108323b1ff5bcc276e58e7